### PR TITLE
Google auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+
+  helper_method :current_user
+
+  def current_user
+    @current_user ||= User.find(session[:id]) if session[:id]
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,4 +4,9 @@ class SessionsController < ApplicationController
     session[:id] = user.id
     redirect_to '/'
   end
+
+  def destroy
+    reset_session
+    redirect_to '/'
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,7 @@
+class SessionsController < ApplicationController
+  def create
+    user = User.update_or_create(request.env['omniauth.auth'])
+    session[:id] = user.id
+    redirect_to '/'
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,15 @@ class User < ApplicationRecord
   validates_uniqueness_of :email
 
   has_many :contacts
+
+  def self.update_or_create(auth)
+    user = User.find_by(email: auth['info']['email']) || User.new
+    user.attributes = {
+      name: auth['info']['first_name'] + ' ' + auth['info']['last_name'],
+      email: auth['info']['email'],
+      google_sso_token: auth['credentials']['token']
+    }
+    user.save!
+    user
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,12 @@
   </head>
 
   <body>
+    <% if !current_user %>
+      <%= link_to "Log In", google_oauth2_login_path %>
+    <% else %>
+      <%= current_user.name %>
+      <%= link_to "Log Out", logout_path %>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -20,7 +20,6 @@
     </style>
   </head>
   <body>
-    <%= link_to "Log In", google_oauth2_login_path %>
     <div id="map"></div>
     <script>
       function initMap() {

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -20,6 +20,7 @@
     </style>
   </head>
   <body>
+    <%= link_to "Log In", google_oauth2_login_path %>
     <div id="map"></div>
     <script>
       function initMap() {

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,3 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
 
   get '/auth/google_oauth2', as: :google_oauth2_login
   get '/auth/google_oauth2/callback', to: 'sessions#create'
+  get :logout, to: 'sessions#destroy'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/', to: 'welcome#index'
+
+  get '/auth/google_oauth2', as: :google_oauth2_login
+  get '/auth/google_oauth2/callback', to: 'sessions#create'
 end

--- a/spec/features/user_logs_in_with_google_spec.rb
+++ b/spec/features/user_logs_in_with_google_spec.rb
@@ -11,6 +11,16 @@ describe 'User' do
     expect(page).to have_content('Kelly Schroeder')
     expect(page).to have_link('Log Out')
   end
+  it 'logs out' do
+    stub_omniauth
+
+    visit '/'
+
+    click_on 'Log In'
+    click_on 'Log Out'
+
+    expect(page).to_not have_content('Kelly Schroeder')
+  end
 
   def stub_omniauth
     OmniAuth.config.test_mode = true

--- a/spec/features/user_logs_in_with_google_spec.rb
+++ b/spec/features/user_logs_in_with_google_spec.rb
@@ -8,6 +8,8 @@ describe 'User' do
 
     click_on 'Log In'
 
+    expect(page).to have_content('Kelly Schroeder')
+    expect(page).to have_link('Log Out')
   end
 
   def stub_omniauth

--- a/spec/features/user_logs_in_with_google_spec.rb
+++ b/spec/features/user_logs_in_with_google_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'User' do
+  it 'logs in via google auth' do
+    stub_omniauth
+
+    visit '/'
+
+    click_on 'Log In'
+
+  end
+
+  def stub_omniauth
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      'provider' => 'google_oauth2',
+      'uid' => '123123123123',
+      'info' =>
+          { 'name' => 'Kelly Schroeder',
+            'email' => 'kellyrschroeder@gmail.com',
+            'first_name' => 'Kelly',
+            'last_name' => 'Schroeder',
+            'image' => 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg',
+            'urls' => { 'Google' => 'https://plus.google.com/103996086299667923542' } },
+      'credentials' => { 'token' => 'definitelysomefaketoken', 'expires_at' => 1_527_533_604, 'expires' => true },
+      'extra' =>
+          { 'id_token' =>
+              'definitelyanotherfaketokenidtokenthing',
+            'raw_info' =>
+                { 'id' => '123123123123123123123123',
+                  'email' => 'kellyrschroeder@gmail.com',
+                  'verified_email' => true,
+                  'name' => 'Kelly Schroeder',
+                  'given_name' => 'Kelly',
+                  'family_name' => 'Schroeder',
+                  'link' => 'https://plus.google.com/103996086299667923542',
+                  'picture' => 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg',
+                  'gender' => 'male',
+                  'locale' => 'en' } }
+    )
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,4 +9,40 @@ describe User do
     it { should validate_presence_of(:google_sso_token) }
     it { should have_many(:contacts) }
   end
+  describe 'methods' do
+    it '#update_or_create' do
+      auth = {
+        'provider' => 'google_oauth2',
+        'uid' => '123123123123',
+        'info' =>
+            { 'name' => 'Kelly Schroeder',
+              'email' => 'kellyrschroeder@gmail.com',
+              'first_name' => 'Kelly',
+              'last_name' => 'Schroeder',
+              'image' => 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg',
+              'urls' => { 'Google' => 'https://plus.google.com/103996086299667923542' } },
+        'credentials' => { 'token' => 'definitelysomefaketoken', 'expires_at' => 1_527_533_604, 'expires' => true },
+        'extra' =>
+            { 'id_token' =>
+                'definitelyanotherfaketokenidtokenthing',
+              'raw_info' =>
+                  { 'id' => '123123123123123123123123',
+                    'email' => 'kellyrschroeder@gmail.com',
+                    'verified_email' => true,
+                    'name' => 'Kelly Schroeder',
+                    'given_name' => 'Kelly',
+                    'family_name' => 'Schroeder',
+                    'link' => 'https://plus.google.com/103996086299667923542',
+                    'picture' => 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg',
+                    'gender' => 'male',
+                    'locale' => 'en' } }
+      }
+      user = User.update_or_create(auth)
+
+      expect(user).to be_instance_of(User)
+      expect(user.name).to eq('Kelly Schroeder')
+      expect(user.email).to eq('kellyrschroeder@gmail.com')
+      expect(user.google_sso_token).to eq('definitelysomefaketoken')
+    end
+  end
 end


### PR DESCRIPTION
bc9035c (HEAD -> google-auth, origin/google-auth) HEAD@{0}: commit: Adds destroy method to sessions controller
b9fa255 HEAD@{1}: commit: Adds test for loggin out
07c86a8 HEAD@{2}: commit: Adds expectations to user loggin in with google spec
a193d27 HEAD@{3}: commit: Adds login/logout functionality to application layout
2a10740 HEAD@{4}: commit: Adds logout path
422905f HEAD@{5}: commit: Removes login link from welcome index
dffb2e9 HEAD@{6}: commit: Adds session create method for sessions controller
53f3953 HEAD@{7}: commit: Adds feature test for logging in with google auth
9036b54 HEAD@{8}: commit: Adds spec test for user method update_or_create
00c1063 HEAD@{9}: commit: Adds method for update_or_create user
3bd27c7 HEAD@{10}: commit: Adds current_user method to app controller
f0d0a47 HEAD@{11}: commit: Adds log link for google auth
39f2ffb HEAD@{12}: commit: Adds route for google auth log in and callback
1495a46 HEAD@{13}: commit: Adds config for omniauth google initializer

https://www.pivotaltracker.com/story/show/157851606